### PR TITLE
RegisterRemote to monitor remote healthz endpoints

### DIFF
--- a/healthz.go
+++ b/healthz.go
@@ -82,6 +82,12 @@ func Set(name string, err error, timeout time.Duration) {
 	DefaultChecker.Set(name, err, timeout)
 }
 
+// RegisterRemote registers a remote /healthz endpoint that needs to be monitored.
+// See Checker.RegisterRemote for details.
+func RegisterRemote(name string, period time.Duration, url string, opt *RemoteOptions) error {
+	return DefaultChecker.RegisterRemote(name, period, url, opt)
+}
+
 // Deregister is a shortcut for DefaultChecker.Deregister. See there for more information.
 func Deregister(name string) {
 	DefaultChecker.Deregister(name)

--- a/healthz_test.go
+++ b/healthz_test.go
@@ -110,6 +110,16 @@ func TestHealthz(t *testing.T) {
 	require.False(t, status.OK)
 	require.Equal(t, "static error", status.Failures["static"])
 
+	// SetMeta to replace a static error
+	ch.Set("static", errors.New("new static error"), 200*time.Millisecond)
+	defer ch.Deregister("static")
+
+	status, code, err = get(s.URL)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusServiceUnavailable, code)
+	require.False(t, status.OK)
+	require.Equal(t, "new static error", status.Failures["static"])
+
 	time.Sleep(200 * time.Millisecond)
 
 	status, code, err = get(s.URL)

--- a/remote.go
+++ b/remote.go
@@ -1,0 +1,130 @@
+package healthz
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// RemoteOptions are options passed to RegisterRemote
+type RemoteOptions struct {
+	// Client allows you to override the default http.Client
+	Client *http.Client // optional client override
+
+	// Timeout allows you to override the default timeout of RemoteDefaultTimeout
+	// used by RegisterRemote. If the Client is overridden, this does nothing.
+	Timeout time.Duration // optional timeout, if the default is not OK
+
+	// AsWarnings instructs RegisterRemote to downgrade any remote errors to
+	// warnings for this check.
+	AsWarnings bool
+
+	// Warn404 make a remote 404 a warning instead of an error. This is useful
+	// if you are not sure if the target url has a healthz endpoint.
+	Warn404 bool
+}
+
+const (
+	// RemoteDefaultTimeout is the default timeout for fetching a remote
+	// healthz in RegisterRemote.
+	RemoteDefaultTimeout = 10 * time.Second
+)
+
+// RegisterRemote registers a remote /healthz endpoint that needs to be monitored.
+// The period parameter determines the poll interval.
+// The url must contain the full url to the healthz endpoint.
+//
+// If the remote endpoint uses the same JSON structure as this instance does,
+// the name is used to prefix all remote failures and warnings, separated
+// by a slash ('/'). E.g. if the name is "foo", a remote "bar" error will end
+// up as "foo/bar" in the status reported by this instance.
+// It the remote endpoint is not served by this library and no compatible
+// failures and warnings keys could be found, this check returns a single error
+// for this endpoint with the requested name.
+func (c *Checker) RegisterRemote(name string, period time.Duration, url string, opt *RemoteOptions) error {
+	var client *http.Client
+	if opt != nil && opt.Client != nil {
+		client = opt.Client
+	} else {
+		timeout := RemoteDefaultTimeout
+		if opt != nil && opt.Timeout > 0 {
+			timeout = opt.Timeout
+		}
+		client = &http.Client{
+			Timeout: timeout,
+		}
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	asWarnings := false
+	errorf := fmt.Errorf
+	if opt != nil {
+		asWarnings = opt.AsWarnings
+		errorf = Warnf
+	}
+
+	c.Register(name, period, func() error {
+		res, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return err
+		}
+
+		// Accept error codes in the 2xx and 5xx range
+		sc := res.StatusCode
+		if sc < 200 || (sc >= 300 && sc < 500) || sc >= 600 {
+			if sc == 404 && opt != nil && opt.Warn404 {
+				return Warnf("remote healthz endpoint does not exist")
+			}
+			return errorf("unexpected healthz http status code: %d", sc)
+		}
+		remoteOK := sc < 300
+
+		// Try to decode as json
+		var st Status
+		if err := json.Unmarshal(body, &st); err != nil {
+			// Not JSON or not the expected format, base on http status code
+			if remoteOK {
+				return nil
+			} else {
+				return errorf("remote http code %d, contents:\n%s", sc, string(body))
+			}
+		}
+		if !remoteOK && len(st.Failures) == 0 {
+			// No failures listed, but we got an error status code, so the remote
+			// json is not compatible with our json.
+			return errorf("remote http code %d, contents:\n%s", sc, string(body))
+		}
+
+		// Extract failures and warnings from another instance that uses the
+		// same reporting format.
+		me := make(ScopedMultiError)
+		for key, msg := range st.Failures {
+			if asWarnings {
+				// Downgrade to warning if requested in RemoteOptions
+				me[key] = Warn(msg)
+			} else {
+				me[key] = errors.New(msg)
+			}
+		}
+		for key, msg := range st.Warnings {
+			me[key] = Warn(msg)
+		}
+		if len(me) == 0 {
+			return nil
+		}
+		return me
+	})
+
+	return nil
+}

--- a/remote_test.go
+++ b/remote_test.go
@@ -1,0 +1,75 @@
+package healthz
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func setTestValues(remote *Checker) {
+	remote.Set("error1", errors.New("error1 value"), 0)
+	remote.Set("error2", errors.New("error2 value"), 0)
+	remote.Set("warning1", Warn("warning1 value"), 0)
+	remote.Set("multi", ScopedMultiError{
+		"e1": errors.New("e1"),
+		"e2": errors.New("e2"),
+		"w1": Warn("w1"),
+	}, 0)
+}
+
+func TestRegisterRemote(t *testing.T) {
+	remote := NewChecker(nil)
+	defer remote.Close()
+	setTestValues(remote)
+
+	server := httptest.NewServer(remote.Handler())
+	defer server.Close()
+
+	local := NewChecker(nil)
+	defer local.Close()
+	err := local.RegisterRemote("remote", time.Second, server.URL, nil)
+	assert.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+
+	st := local.Status()
+	assert.Len(t, st.Failures, 4)
+	assert.Len(t, st.Warnings, 2)
+	assert.Equal(t, "error1 value", st.Failures["remote/error1"])
+	assert.Equal(t, "error2 value", st.Failures["remote/error2"])
+	assert.Equal(t, "warning1 value", st.Warnings["remote/warning1"])
+	assert.Equal(t, "e1", st.Failures["remote/multi/e1"])
+	assert.Equal(t, "e2", st.Failures["remote/multi/e2"])
+	assert.Equal(t, "w1", st.Warnings["remote/multi/w1"])
+}
+
+func TestRegisterRemote_asWarnings(t *testing.T) {
+	remote := NewChecker(nil)
+	defer remote.Close()
+	setTestValues(remote)
+
+	server := httptest.NewServer(remote.Handler())
+	defer server.Close()
+
+	local := NewChecker(nil)
+	defer local.Close()
+	err := local.RegisterRemote("remote", time.Second, server.URL, &RemoteOptions{
+		AsWarnings: true,
+	})
+	assert.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+
+	st := local.Status()
+	assert.Len(t, st.Failures, 0)
+	assert.Len(t, st.Warnings, 6)
+	assert.Equal(t, "error1 value", st.Warnings["remote/error1"])
+	assert.Equal(t, "error2 value", st.Warnings["remote/error2"])
+	assert.Equal(t, "warning1 value", st.Warnings["remote/warning1"])
+	assert.Equal(t, "e1", st.Warnings["remote/multi/e1"])
+	assert.Equal(t, "e2", st.Warnings["remote/multi/e2"])
+	assert.Equal(t, "w1", st.Warnings["remote/multi/w1"])
+}

--- a/scoped.go
+++ b/scoped.go
@@ -1,0 +1,31 @@
+package healthz
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ScopedMultiError contains multiple errors keyed by a unique name
+type ScopedMultiError map[string]error
+
+func (e ScopedMultiError) Error() string {
+	var sb strings.Builder
+	sb.WriteString("multiple errors:")
+	var keys []string
+	for key := range e {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys) // for deterministic output order
+	for _, key := range keys {
+		_, _ = fmt.Fprintf(&sb, "\n%s: %v", key, e[key])
+	}
+	return sb.String()
+}
+
+// IsScopedMultiError returns true if the error is a ScopedMultiError.
+// It will NOT attempt to unwrap the error.
+func IsScopedMultiError(err error) bool {
+	_, ok := err.(ScopedMultiError)
+	return ok
+}

--- a/scoped_test.go
+++ b/scoped_test.go
@@ -1,0 +1,23 @@
+package healthz
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsScopedMultiError(t *testing.T) {
+	me := ScopedMultiError{
+		"foo": errors.New("foo-error"),
+		"bar": errors.New("bar-error"),
+	}
+	require.Equal(t, "multiple errors:\nbar: bar-error\nfoo: foo-error", me.Error())
+	require.True(t, IsScopedMultiError(me))
+}
+
+func TestIsScopedMultiError_empty(t *testing.T) {
+	me := ScopedMultiError{}
+	require.Equal(t, "multiple errors:", me.Error())
+	require.True(t, IsScopedMultiError(me))
+}

--- a/warnings.go
+++ b/warnings.go
@@ -1,6 +1,9 @@
 package healthz
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // Warning is a type of error that is considered a warning instead of a failure.
 // It will not cause the health check to fail, but the warning will appear
@@ -24,7 +27,13 @@ func Warnf(format string, args ...interface{}) error {
 }
 
 // IsWarning returns true if the error is a Warning instead of a failure.
+// It will recursively unwrap the error to look for a Warning.
 func IsWarning(err error) bool {
-	_, ok := err.(Warning)
-	return ok
+	for err != nil {
+		if _, ok := err.(Warning); ok {
+			return true
+		}
+		err = errors.Unwrap(err)
+	}
+	return false
 }

--- a/warnings_test.go
+++ b/warnings_test.go
@@ -1,0 +1,17 @@
+package healthz
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsWarning(t *testing.T) {
+	assert.False(t, IsWarning(errors.New("foo")))
+	assert.True(t, IsWarning(Warn("foo")))
+	assert.True(t, IsWarning(Warnf("foo %d", 42)))
+	assert.True(t, IsWarning(fmt.Errorf("wrapped: %w", Warn("foo"))))
+	assert.False(t, IsWarning(fmt.Errorf("not wrapped: %v", Warn("foo"))))
+}


### PR DESCRIPTION
- Add RegisterRemote method to include checks from a remote heath endpoint
- Add ScopedMultiError to return multiple errors from a single check, which is also used by the remote check
- Add Close method to clear all checks from a Checker
- Make IsWarning recursively unwrap errors