### PR TITLE
Warnings now wrap errors

### DIFF
--- a/warnings.go
+++ b/warnings.go
@@ -9,21 +9,25 @@ import (
 // It will not cause the health check to fail, but the warning will appear
 // in the JSON.
 type Warning struct {
-	msg string
+	Err error
 }
 
 func (w Warning) Error() string {
-	return w.msg
+	return w.Err.Error()
+}
+
+func (w Warning) Unwrap() error {
+	return w.Err
 }
 
 // Warn returns a Warning with given message
 func Warn(msg string) error {
-	return Warning{msg: msg}
+	return Warning{errors.New(msg)}
 }
 
 // Warnf formats a Warning
 func Warnf(format string, args ...interface{}) error {
-	return Warning{msg: fmt.Sprintf(format, args...)}
+	return Warning{fmt.Errorf(format, args...)}
 }
 
 // IsWarning returns true if the error is a Warning instead of a failure.

--- a/warnings_test.go
+++ b/warnings_test.go
@@ -14,4 +14,20 @@ func TestIsWarning(t *testing.T) {
 	assert.True(t, IsWarning(Warnf("foo %d", 42)))
 	assert.True(t, IsWarning(fmt.Errorf("wrapped: %w", Warn("foo"))))
 	assert.False(t, IsWarning(fmt.Errorf("not wrapped: %v", Warn("foo"))))
+	assert.True(t, IsWarning(Warnf("can wrap errors: %w", errors.New("foo"))))
+}
+
+func TestWarning_Unwrap(t *testing.T) {
+	orig := errors.New("test")
+	w := Warning{Err: orig}
+	err := errors.Unwrap(w)
+	assert.Equal(t, orig, err)
+}
+
+func TestWarning_Unwrap2(t *testing.T) {
+	orig := errors.New("test")
+	w := Warnf("test wrap: %w", orig)
+	err := errors.Unwrap(w)
+	err = errors.Unwrap(err)
+	assert.Equal(t, orig, err)
 }


### PR DESCRIPTION
Make warning wrap an error instead of message string. This allows unwrapping any original errors and makes it possible to directly use Warning to wrap an existing error.

This also enables the use of `%w` in Warnf.